### PR TITLE
Drop bits-extras in favour of System.Endian

### DIFF
--- a/base32-bytestring.cabal
+++ b/base32-bytestring.cabal
@@ -41,7 +41,6 @@ library
   build-depends:       base        == 4.*
                      , bytestring  >= 0.9
                      , cpu         == 0.1.*
-                     , bits-extras == 0.1.*
   ghc-options:         -O2 -Wall
 
 test-suite spec


### PR DESCRIPTION
bits-extras is causing compilation issues. Drop the dependency in favour
of the more portable `System.Endian` equivalent functions.

fixes #2 